### PR TITLE
修复单例环形图的bug,允许dev依赖引入

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,6 +5,6 @@ module.exports = {
     'global-require': 0,
     'no-shadow': 0,
     'operator-assignment': 0,
-    'import/no-extraneous-dependencies': 0,
+    'import/no-extraneous-dependencies': ['error', { devDependencies: true }],
   },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,8 +2,9 @@ module.exports = {
   extends: [require.resolve('@umijs/fabric/dist/eslint')],
   rules: {
     // your rules
-    "global-require": 0,
-    "no-shadow": 0,
-    "operator-assignment": 0
+    'global-require': 0,
+    'no-shadow': 0,
+    'operator-assignment': 0,
+    'import/no-extraneous-dependencies': 0,
   },
 };

--- a/packages/charts/src/utils/create-donut-plot/index.ts
+++ b/packages/charts/src/utils/create-donut-plot/index.ts
@@ -4,7 +4,7 @@
  * @作者: 阮旭松
  * @Date: 2020-04-27 14:53:56
  * @LastEditors: 阮旭松
- * @LastEditTime: 2020-05-25 12:02:55
+ * @LastEditTime: 2020-05-25 15:10:20
  */
 import { Donut, RingConfig, DataItem, StateManager } from '@antv/g2plot';
 import G2DonutLayer, { DonutViewConfig } from '@antv/g2plot/lib/plots/donut/layer';
@@ -175,7 +175,7 @@ const createDonutPlot = ({ dom, data, config }: RingPlotCreateProps) => {
               },
               {
                 stroke: donutThemeConfig.stroke,
-                lineWidth: bordered ? 6 : 0,
+                lineWidth: !bordered || isSingle ? 0 : 6,
               },
             );
           },

--- a/packages/charts/src/utils/create-liquid-plot/index.ts
+++ b/packages/charts/src/utils/create-liquid-plot/index.ts
@@ -4,7 +4,7 @@
  * @作者: 阮旭松
  * @Date: 2020-04-27 14:53:56
  * @LastEditors: 阮旭松
- * @LastEditTime: 2020-05-25 11:46:45
+ * @LastEditTime: 2020-05-29 16:22:04
  */
 import { Liquid, LiquidConfig } from '@antv/g2plot';
 import { PlotCreateProps, basePieConfig, themeConfig } from '../../config';
@@ -26,7 +26,7 @@ const createLiquidPlot = ({ dom, data, config }: LiquidPlotCreateProps) => {
   const liquidPlot = new Liquid(dom, {
     ...basePieConfig,
     color: '#10ADF9',
-    padding: [0, 0, 30, -50],
+    padding: [0, 0, 10, 0],
     min: 0,
     max: 100,
     value: data,


### PR DESCRIPTION
1.修复单例环形图的hover事件的边框bug
2.允许 devDependencies 依赖引入，减少组件库体积(组件库没必要的依赖如：react,react-dom可以放到devDependencies中)。