### PR TITLE
所有图表支持config自动深层merge，新增 formatConfig 方法,引入类型

### DIFF
--- a/packages/charts/README.md
+++ b/packages/charts/README.md
@@ -267,6 +267,14 @@ export const themeInit = (customTheme?: string) => {
       legendColor: 'rgba(255, 255, 255, 0.6)',
       // 图表文字颜色
       fontColor: 'rgba(255, 255, 255, 0.4)',
+      // 坐标轴线颜色
+      axisStyle: {
+        stroke: '#666',
+      },
+      // grid颜色
+      gridStyle: {
+        stroke: '#999',
+      },
       // 环形图
       donutConfig: {
         // 环形边缘颜色(间隔颜色)
@@ -291,6 +299,14 @@ export const themeInit = (customTheme?: string) => {
       legendColor: '#666',
       // 图表文字颜色
       fontColor: '#666',
+      // 坐标轴线颜色
+      axisStyle: {
+        stroke: '#ddd',
+      },
+      // grid颜色
+      gridStyle: {
+        stroke: '#ddd',
+      },
       // 环形图
       donutConfig: {
         // 环形边缘颜色(间隔颜色)

--- a/packages/charts/src/baseUtils/chart/index.ts
+++ b/packages/charts/src/baseUtils/chart/index.ts
@@ -4,7 +4,7 @@
  * @作者: 阮旭松
  * @Date: 2020-06-21 22:40:19
  * @LastEditors: 阮旭松
- * @LastEditTime: 2020-07-04 20:18:15
+ * @LastEditTime: 2020-07-06 11:40:22
  */
 
 import { isEqual } from 'lodash-es';
@@ -15,11 +15,11 @@ interface SingleChartHOCConfig<T, U, P> {
   /** 状态管理绑定函数 */
   stateManagerFunc?: (chart: P, data: U, config?: T) => void;
   /** 获得原始配置的方法 */
-  getOriginConfig?: (data: U, config?: T, formatConfig?: (config: Partial<T>) => Partial<T>) => T;
+  getOriginConfig?: (data: U, config?: T, replaceConfig?: (config: Partial<T>) => Partial<T>) => T;
 }
 
 /**
- * @功能描述: 图表配置合并方法，用targetConfig上的属性替换originConfig上的对应属性并得到最后的对象(深层替换)
+ * @功能描述: 图表配置合并方法，用targetConfig上的属性替换originConfig上的对应属性并得到最后的对象(增量复写)
  * @参数: originConfig 原配置，targetConfig：目标配置
  * @返回值: 返回合并后的 config
  */
@@ -40,25 +40,24 @@ export const mergeConfig = <T>(originConfig: Partial<T>, targetConfig: Partial<T
 };
 
 /**
- * @功能描述: 图表配置加工方法，如果不传 formatConfig 使用 mergeConfig 方法深层替换合并配置，
- * 如果传 formatConfig 则不用 mergeConfig 方法，而传入的 config 将会是覆盖模式（属性全部替换），
- * 使用 formatConfig 方法对config 进行配置，可以实现完全自定义图表配置
- * @参数: originConfig 原配置，targetConfig：目标配置，formatConfig：配置格式化函数
+ * @功能描述: 图表配置加工方法，如果不传 replaceConfig 使用 mergeConfig 方法增量复写配置，
+ * 如果传 replaceConfig 则使用全量替换，此时传入的 config 将会是全量替换，
+ * @参数: originConfig 原配置，targetConfig：目标配置，replaceConfig：配置格式化函数
  * @返回值: 返回格式化加工后的 config
  */
 export const formatMergeConfig = <T>(
   originConfig: T,
   targetConfig: Partial<T>,
-  formatConfig?: (config: Partial<T>) => Partial<T>,
+  replaceConfig?: (config: Partial<T>) => Partial<T>,
 ) => {
-  const mergedConfig = mergeConfig<T>(originConfig, targetConfig) as T;
-  let modifiedConfig = mergedConfig;
-
   // 使用自定义配置函数
-  if (formatConfig) {
-    modifiedConfig = formatConfig(mergedConfig) as T;
+  if (replaceConfig) {
+    return replaceConfig({
+      ...originConfig,
+      ...targetConfig,
+    }) as T;
   }
-  return modifiedConfig;
+  return mergeConfig<T>(originConfig, targetConfig) as T;
 };
 
 /**
@@ -75,18 +74,18 @@ export class SingleChartHOC<T, U, P extends BasePlot<T> | CustomBase<T>> {
     dom,
     data,
     config,
-    formatConfig,
+    replaceConfig,
   }: {
     dom: HTMLElement;
     data: U;
     config?: T;
-    formatConfig?: (config: Partial<T>) => Partial<T>;
+    replaceConfig?: (config: Partial<T>) => Partial<T>;
   }) => P;
 
   private stateManagerFunc: ((chart: P, data: U, config?: T) => void) | null;
 
   private getOriginConfig:
-    | ((data: U, config?: T, formatConfig?: (config: Partial<T>) => Partial<T>) => T)
+    | ((data: U, config?: T, replaceConfig?: (config: Partial<T>) => Partial<T>) => T)
     | null;
 
   private domArr: HTMLElement[] = [];
@@ -96,12 +95,12 @@ export class SingleChartHOC<T, U, P extends BasePlot<T> | CustomBase<T>> {
       dom,
       data,
       config,
-      formatConfig,
+      replaceConfig,
     }: {
       dom: HTMLElement;
       data: U;
       config?: T;
-      formatConfig?: (config: Partial<T>) => Partial<T>;
+      replaceConfig?: (config: Partial<T>) => Partial<T>;
     }) => P,
     config?: SingleChartHOCConfig<T, U, P>,
   ) {
@@ -115,17 +114,17 @@ export class SingleChartHOC<T, U, P extends BasePlot<T> | CustomBase<T>> {
     dom,
     data,
     config,
-    formatConfig,
+    replaceConfig,
   }: {
     dom: HTMLElement;
     data: U;
     config?: T;
-    formatConfig?: (config: Partial<T>) => Partial<T>;
+    replaceConfig?: (config: Partial<T>) => Partial<T>;
   }) {
     const idx = this.domArr.findIndex(item => item === dom);
     if (idx === -1) {
       // 初次渲染图表
-      const plot = this.getDom({ dom, data, config, formatConfig });
+      const plot = this.getDom({ dom, data, config, replaceConfig });
       this.chartPlotArr.push(plot);
       this.dataArr.push(data);
       this.domArr.push(dom);
@@ -135,13 +134,13 @@ export class SingleChartHOC<T, U, P extends BasePlot<T> | CustomBase<T>> {
       this.dataArr[idx] = data;
       // 经过图表方法内部的格式化后的原始配置
       const originConfig = this.getOriginConfig
-        ? this.getOriginConfig(data, config, formatConfig)
+        ? this.getOriginConfig(data, config, replaceConfig)
         : ({} as T);
       // 更新 config 并重新加载图表
       this.chartPlotArr[idx].updateConfig({
         data,
-        // 使用外部传入的 formatConfig 方法再次 format
-        ...formatMergeConfig(originConfig, config || {}, formatConfig),
+        // 使用外部传入的 replaceConfig 方法再次 format
+        ...formatMergeConfig(originConfig, config || {}, replaceConfig),
       });
       this.chartPlotArr[idx].render();
       // 绑定状态管理函数
@@ -163,24 +162,24 @@ export const createSingleChart = <T, U, P extends BasePlot<T> | CustomBase<T>>(
     dom,
     data,
     config,
-    formatConfig,
+    replaceConfig,
   }: {
     dom: HTMLElement;
     data: U;
     config?: T;
-    formatConfig?: (config: Partial<T>) => Partial<T>;
+    replaceConfig?: (config: Partial<T>) => Partial<T>;
   }) => P,
   chartConfig?: SingleChartHOCConfig<T, U, P>,
 ): (({
   dom,
   data,
   config,
-  formatConfig,
+  replaceConfig,
 }: {
   dom: HTMLElement;
   data: U;
   config?: T;
-  formatConfig?: (config: Partial<T>) => Partial<T>;
+  replaceConfig?: (config: Partial<T>) => Partial<T>;
 }) => P) => {
   const newChart = new SingleChartHOC<T, U, P>(getDom, chartConfig);
   return newChart.render.bind(newChart);

--- a/packages/charts/src/baseUtils/chart/index.ts
+++ b/packages/charts/src/baseUtils/chart/index.ts
@@ -4,54 +4,128 @@
  * @作者: 阮旭松
  * @Date: 2020-06-21 22:40:19
  * @LastEditors: 阮旭松
- * @LastEditTime: 2020-06-28 17:53:41
+ * @LastEditTime: 2020-07-04 20:18:15
  */
 
 import { isEqual } from 'lodash-es';
-import { DataItem } from '../../config';
+import BasePlot from '@antv/g2plot/lib/base/plot';
+import CustomBase from '../../g2components/base';
 
-interface SingleChartHOCConfig {
+interface SingleChartHOCConfig<T, U, P> {
   /** 状态管理绑定函数 */
-  stateManagerFunc?: (chart: any, data: DataItem[], config?: any) => void;
-  /** 对 data 的格式化处理 */
-  dataFormat?: (data: any, config?: any) => any;
-  /** 对 config 的格式化处理 */
-  configFormat?: (data: any, config?: any) => any;
+  stateManagerFunc?: (chart: P, data: U, config?: T) => void;
+  /** 获得原始配置的方法 */
+  getOriginConfig?: (data: U, config?: T, formatConfig?: (config: Partial<T>) => Partial<T>) => T;
 }
+
+/**
+ * @功能描述: 图表配置合并方法，用targetConfig上的属性替换originConfig上的对应属性并得到最后的对象(深层替换)
+ * @参数: originConfig 原配置，targetConfig：目标配置
+ * @返回值: 返回合并后的 config
+ */
+export const mergeConfig = <T>(originConfig: Partial<T>, targetConfig: Partial<T>) => {
+  const modifiedObj = Object.assign({}, originConfig, targetConfig);
+  Object.keys(modifiedObj).forEach(key => {
+    // 如果是 originConfig，targetConfig上都有的属性且为对象,再合并一次
+    if (
+      originConfig[key] &&
+      targetConfig[key] &&
+      typeof targetConfig[key] === 'object' &&
+      !Array.isArray(targetConfig[key])
+    ) {
+      modifiedObj[key] = mergeConfig(originConfig[key], targetConfig[key]);
+    }
+  });
+  return modifiedObj;
+};
+
+/**
+ * @功能描述: 图表配置加工方法，如果不传 formatConfig 使用 mergeConfig 方法深层替换合并配置，
+ * 如果传 formatConfig 则不用 mergeConfig 方法，而传入的 config 将会是覆盖模式（属性全部替换），
+ * 使用 formatConfig 方法对config 进行配置，可以实现完全自定义图表配置
+ * @参数: originConfig 原配置，targetConfig：目标配置，formatConfig：配置格式化函数
+ * @返回值: 返回格式化加工后的 config
+ */
+export const formatMergeConfig = <T>(
+  originConfig: T,
+  targetConfig: Partial<T>,
+  formatConfig?: (config: Partial<T>) => Partial<T>,
+) => {
+  const mergedConfig = mergeConfig<T>(originConfig, targetConfig) as T;
+  let modifiedConfig = mergedConfig;
+
+  // 使用自定义配置函数
+  if (formatConfig) {
+    modifiedConfig = formatConfig(mergedConfig) as T;
+  }
+  return modifiedConfig;
+};
 
 /**
  * 图表包装方法 HOC
  * 用于更新图表 config 并防止重复渲染
  * 注：返回 render 方法时需要 bind(实例名)否则无 this
  */
-export class SingleChartHOC {
-  private dataArr: any[] = [];
+export class SingleChartHOC<T, U, P extends BasePlot<T> | CustomBase<T>> {
+  private dataArr: U[] = [];
 
   private chartPlotArr: any[] = [];
 
-  private getDom: any;
+  private getDom: ({
+    dom,
+    data,
+    config,
+    formatConfig,
+  }: {
+    dom: HTMLElement;
+    data: U;
+    config?: T;
+    formatConfig?: (config: Partial<T>) => Partial<T>;
+  }) => P;
 
-  private stateManagerFunc: ((chart: any, data: DataItem[], config?: any) => void) | null;
+  private stateManagerFunc: ((chart: P, data: U, config?: T) => void) | null;
 
-  private dataFormat: ((data: any, config?: any) => any) | null;
-
-  private configFormat: ((data: any, config?: any) => any) | null;
+  private getOriginConfig:
+    | ((data: U, config?: T, formatConfig?: (config: Partial<T>) => Partial<T>) => T)
+    | null;
 
   private domArr: HTMLElement[] = [];
 
-  constructor(getDom: any, config?: SingleChartHOCConfig) {
-    const { stateManagerFunc = null, dataFormat = null, configFormat = null } = config || {};
+  constructor(
+    getDom: ({
+      dom,
+      data,
+      config,
+      formatConfig,
+    }: {
+      dom: HTMLElement;
+      data: U;
+      config?: T;
+      formatConfig?: (config: Partial<T>) => Partial<T>;
+    }) => P,
+    config?: SingleChartHOCConfig<T, U, P>,
+  ) {
+    const { stateManagerFunc = null, getOriginConfig = null } = config || {};
     this.getDom = getDom;
     this.stateManagerFunc = stateManagerFunc;
-    this.dataFormat = dataFormat;
-    this.configFormat = configFormat;
+    this.getOriginConfig = getOriginConfig;
   }
 
-  render({ dom, data, config }: { dom: HTMLElement; data: any; config: any }) {
+  render({
+    dom,
+    data,
+    config,
+    formatConfig,
+  }: {
+    dom: HTMLElement;
+    data: U;
+    config?: T;
+    formatConfig?: (config: Partial<T>) => Partial<T>;
+  }) {
     const idx = this.domArr.findIndex(item => item === dom);
     if (idx === -1) {
       // 初次渲染图表
-      const plot = this.getDom({ dom, data, config });
+      const plot = this.getDom({ dom, data, config, formatConfig });
       this.chartPlotArr.push(plot);
       this.dataArr.push(data);
       this.domArr.push(dom);
@@ -59,12 +133,15 @@ export class SingleChartHOC {
     }
     if (!isEqual(this.dataArr[idx], data)) {
       this.dataArr[idx] = data;
+      // 经过图表方法内部的格式化后的原始配置
+      const originConfig = this.getOriginConfig
+        ? this.getOriginConfig(data, config, formatConfig)
+        : ({} as T);
       // 更新 config 并重新加载图表
       this.chartPlotArr[idx].updateConfig({
-        // 添加 config 格式化的属性
-        ...(this.configFormat ? this.configFormat(data, config) : {}),
-        // 对数据进行格式化
-        data: this.dataFormat ? this.dataFormat(data, config) : data,
+        data,
+        // 使用外部传入的 formatConfig 方法再次 format
+        ...formatMergeConfig(originConfig, config || {}, formatConfig),
       });
       this.chartPlotArr[idx].render();
       // 绑定状态管理函数
@@ -81,7 +158,30 @@ export class SingleChartHOC {
  *  @param getDom：各种图表 create 方法
  *  @param config：图表 data 格式化，状态机管理等图表配置
  */
-export const createSingleChart = (getDom: any, chartConfig?: SingleChartHOCConfig) => {
-  const newChart = new SingleChartHOC(getDom, chartConfig);
+export const createSingleChart = <T, U, P extends BasePlot<T> | CustomBase<T>>(
+  getDom: ({
+    dom,
+    data,
+    config,
+    formatConfig,
+  }: {
+    dom: HTMLElement;
+    data: U;
+    config?: T;
+    formatConfig?: (config: Partial<T>) => Partial<T>;
+  }) => P,
+  chartConfig?: SingleChartHOCConfig<T, U, P>,
+): (({
+  dom,
+  data,
+  config,
+  formatConfig,
+}: {
+  dom: HTMLElement;
+  data: U;
+  config?: T;
+  formatConfig?: (config: Partial<T>) => Partial<T>;
+}) => P) => {
+  const newChart = new SingleChartHOC<T, U, P>(getDom, chartConfig);
   return newChart.render.bind(newChart);
 };

--- a/packages/charts/src/config.ts
+++ b/packages/charts/src/config.ts
@@ -108,7 +108,7 @@ export interface PlotCreateProps<T> {
   data: DataItem[];
   config?: T;
   /** 自定义配置函数,传入时对 config 进行配置 */
-  formatConfig?: (config: Partial<T>) => Partial<T>;
+  replaceConfig?: (config: Partial<T>) => Partial<T>;
 }
 
 export interface CustomWindow extends Window {

--- a/packages/charts/src/config.ts
+++ b/packages/charts/src/config.ts
@@ -4,7 +4,7 @@
  * @作者: 廖军
  * @Date: 2020-04-27 10:23:02
  * @LastEditors: 阮旭松
- * @LastEditTime: 2020-07-01 18:17:18
+ * @LastEditTime: 2020-07-04 20:16:08
  */
 
 import {
@@ -41,6 +41,14 @@ const defaultThemeConfig = {
   dark: {
     legendColor: 'rgba(255, 255, 255, 0.6)',
     fontColor: 'rgba(255, 255, 255, 0.4)',
+    // 坐标轴线颜色
+    axisStyle: {
+      stroke: '#666',
+    },
+    // grid颜色
+    gridStyle: {
+      stroke: '#999',
+    },
     // 环形图
     donutConfig: {
       stroke: '#122749',
@@ -61,6 +69,14 @@ const defaultThemeConfig = {
   light: {
     legendColor: '#666',
     fontColor: '#666',
+    // 坐标轴线颜色
+    axisStyle: {
+      stroke: '#ddd',
+    },
+    // grid颜色
+    gridStyle: {
+      stroke: '#ddd',
+    },
     // 环形图
     donutConfig: {
       stroke: '#fff',
@@ -91,6 +107,8 @@ export interface PlotCreateProps<T> {
   dom: HTMLElement;
   data: DataItem[];
   config?: T;
+  /** 自定义配置函数,传入时对 config 进行配置 */
+  formatConfig?: (config: Partial<T>) => Partial<T>;
 }
 
 export interface CustomWindow extends Window {
@@ -114,7 +132,7 @@ export const textStyle: TextStyle = {
 // 坐标轴线配置
 export const axisStyle = {
   visible: true,
-  style: { lineWidth: 1, stroke: '#ddd' },
+  style: { lineWidth: 1, stroke: themeConfig.axisStyle.stroke },
 };
 
 // 线配置
@@ -185,7 +203,7 @@ export const getResponseTextStyle = () => {
 export const baseGridLine = {
   visible: true,
   line: {
-    style: { lineWidth: 0.5, stroke: '#ddd' },
+    style: { lineWidth: 0.5, stroke: themeConfig.gridStyle.stroke },
   },
 };
 
@@ -227,7 +245,7 @@ export const baseComboYAxis: ComboYAxisConfig = {
   line: {
     visible: true,
     style: {
-      stroke: '#ddd',
+      stroke: themeConfig.axisStyle.stroke,
       lineWidth: 1,
     },
   },

--- a/packages/charts/src/utils/create-column-line-plot/index.ts
+++ b/packages/charts/src/utils/create-column-line-plot/index.ts
@@ -65,9 +65,9 @@ export const getColumnLineConfig = (
 const getOriginConfig = (
   data: DataItem[][],
   config?: CustomColumnLineConfig,
-  formatConfig?: (config: CustomColumnLineConfig) => CustomColumnLineConfig,
+  replaceConfig?: (config: CustomColumnLineConfig) => CustomColumnLineConfig,
 ) => {
-  const transformedConfig = formatConfig ? formatConfig(config || {}) : config;
+  const transformedConfig = replaceConfig ? replaceConfig(config || {}) : config;
   const plotConfig = getColumnLineConfig(data, transformedConfig);
   return {
     ...baseComboConfig,
@@ -85,15 +85,15 @@ const getOriginConfig = (
   };
 };
 
-const createColumnLinePlot = ({ dom, data, config = {}, formatConfig }: ColumnLineCreateProps) => {
+const createColumnLinePlot = ({ dom, data, config = {}, replaceConfig }: ColumnLineCreateProps) => {
   const { isSingleAxis, ...restConfig } = config || {};
 
   const plot = new ColumnLine(
     dom,
     formatMergeConfig<ColumnLineConfig>(
-      getOriginConfig(data, config, formatConfig),
+      getOriginConfig(data, config, replaceConfig),
       restConfig,
-      formatConfig,
+      replaceConfig,
     ),
   );
 

--- a/packages/charts/src/utils/create-column-plot/index.ts
+++ b/packages/charts/src/utils/create-column-plot/index.ts
@@ -20,11 +20,11 @@ const createColumnPlot = ({
   dom,
   data,
   config = {},
-  formatConfig,
+  replaceConfig,
 }: PlotCreateProps<ColumnConfig>) => {
   const plot = new Column(
     dom,
-    formatMergeConfig<ColumnConfig>(getOriginConfig(data), config, formatConfig),
+    formatMergeConfig<ColumnConfig>(getOriginConfig(data), config, replaceConfig),
   );
 
   plot.render();

--- a/packages/charts/src/utils/create-column-plot/index.ts
+++ b/packages/charts/src/utils/create-column-plot/index.ts
@@ -4,21 +4,33 @@
  * @作者: 廖军
  * @Date: 2020-04-27 13:56:23
  * @LastEditors: 阮旭松
- * @LastEditTime: 2020-06-22 10:03:53
+ * @LastEditTime: 2020-07-04 18:45:41
  */
 import { Column, ColumnConfig } from '@antv/g2plot';
-import { baseConfig, PlotCreateProps } from '../../config';
-import { createSingleChart } from '../../baseUtils/chart';
+import { baseConfig, PlotCreateProps, DataItem } from '../../config';
+import { createSingleChart, formatMergeConfig } from '../../baseUtils/chart';
 
-const createColumnPlot = ({ dom, data, config = {} }: PlotCreateProps<ColumnConfig>) => {
-  const plot = new Column(dom, {
-    ...baseConfig,
-    data,
-    ...config,
-  });
+/** 获得原始配置 */
+const getOriginConfig = (data: DataItem[]) => ({
+  ...baseConfig,
+  data,
+});
+
+const createColumnPlot = ({
+  dom,
+  data,
+  config = {},
+  formatConfig,
+}: PlotCreateProps<ColumnConfig>) => {
+  const plot = new Column(
+    dom,
+    formatMergeConfig<ColumnConfig>(getOriginConfig(data), config, formatConfig),
+  );
 
   plot.render();
   return plot;
 };
 
-export default createSingleChart(createColumnPlot);
+export default createSingleChart<ColumnConfig, DataItem[], Column>(createColumnPlot, {
+  getOriginConfig,
+});

--- a/packages/charts/src/utils/create-custom-bar-plot/index.ts
+++ b/packages/charts/src/utils/create-custom-bar-plot/index.ts
@@ -4,25 +4,37 @@
  * @作者: 廖军
  * @Date: 2020-04-28 14:51:33
  * @LastEditors: 阮旭松
- * @LastEditTime: 2020-06-22 10:42:07
+ * @LastEditTime: 2020-07-04 18:46:45
  */
-import { PlotCreateProps, baseConfig, hideAxisConfig } from '../../config';
+import { PlotCreateProps, baseConfig, hideAxisConfig, DataItem } from '../../config';
 import CustomBar, { CustomBarConfig } from '../../g2components/CustomBar';
-import { createSingleChart } from '../../baseUtils/chart';
+import { createSingleChart, formatMergeConfig } from '../../baseUtils/chart';
 
-const createDonutRosePlot = ({ dom, data, config = {} }: PlotCreateProps<CustomBarConfig>) => {
-  const plot = new CustomBar(dom, {
-    ...baseConfig,
-    xAxis: hideAxisConfig,
-    yAxis: hideAxisConfig,
-    data,
-    color: 'l(0) 0:rgba(24, 137, 243, 1) 1:rgba(0, 210, 255, 1)',
-    ...config,
-  });
+/** 获得原始配置 */
+const getOriginConfig = (data: DataItem[]) => ({
+  ...baseConfig,
+  xAxis: hideAxisConfig,
+  yAxis: hideAxisConfig,
+  data,
+  color: 'l(0) 0:rgba(24, 137, 243, 1) 1:rgba(0, 210, 255, 1)',
+});
+
+const createDonutRosePlot = ({
+  dom,
+  data,
+  config = {},
+  formatConfig,
+}: PlotCreateProps<CustomBarConfig>) => {
+  const plot = new CustomBar(
+    dom,
+    formatMergeConfig<CustomBarConfig>(getOriginConfig(data), config, formatConfig),
+  );
 
   plot.render();
 
   return plot;
 };
 
-export default createSingleChart(createDonutRosePlot);
+export default createSingleChart<CustomBarConfig, DataItem[], CustomBar>(createDonutRosePlot, {
+  getOriginConfig,
+});

--- a/packages/charts/src/utils/create-custom-bar-plot/index.ts
+++ b/packages/charts/src/utils/create-custom-bar-plot/index.ts
@@ -23,11 +23,11 @@ const createDonutRosePlot = ({
   dom,
   data,
   config = {},
-  formatConfig,
+  replaceConfig,
 }: PlotCreateProps<CustomBarConfig>) => {
   const plot = new CustomBar(
     dom,
-    formatMergeConfig<CustomBarConfig>(getOriginConfig(data), config, formatConfig),
+    formatMergeConfig<CustomBarConfig>(getOriginConfig(data), config, replaceConfig),
   );
 
   plot.render();

--- a/packages/charts/src/utils/create-custom-grouped-bar-plot/index.ts
+++ b/packages/charts/src/utils/create-custom-grouped-bar-plot/index.ts
@@ -4,31 +4,40 @@
  * @作者: 廖军
  * @Date: 2020-04-30 14:06:37
  * @LastEditors: 阮旭松
- * @LastEditTime: 2020-06-22 10:05:43
+ * @LastEditTime: 2020-07-04 18:48:17
  */
-import { PlotCreateProps, baseConfig, baseXAxis, baseYAxis } from '../../config';
+import { PlotCreateProps, baseConfig, baseXAxis, baseYAxis, DataItem } from '../../config';
 import CustomGroupedBar, { CustomGroupedBarConfig } from '../../g2components/CustomGroupedBar';
-import { createSingleChart } from '../../baseUtils/chart';
+import { createSingleChart, formatMergeConfig } from '../../baseUtils/chart';
+
+/** 获得原始配置 */
+const getOriginConfig = (data: DataItem[]) => ({
+  ...baseConfig,
+  xAxis: baseXAxis,
+  yAxis: baseYAxis,
+  data,
+  color: [
+    'l(0) 0:rgba(236, 103, 37, 1) 1:rgba(254, 176, 30, 1)',
+    'l(0) 0:rgba(24, 137, 243, 1) 1:rgba(0, 210, 255, 1)',
+  ],
+});
 
 const createCustomGroupedBarPlot = ({
   dom,
   data,
   config = {},
+  formatConfig,
 }: PlotCreateProps<CustomGroupedBarConfig>) => {
-  const plot = new CustomGroupedBar(dom, {
-    ...baseConfig,
-    xAxis: baseXAxis,
-    yAxis: baseYAxis,
-    data,
-    color: [
-      'l(0) 0:rgba(236, 103, 37, 1) 1:rgba(254, 176, 30, 1)',
-      'l(0) 0:rgba(24, 137, 243, 1) 1:rgba(0, 210, 255, 1)',
-    ],
-    ...config,
-  });
+  const plot = new CustomGroupedBar(
+    dom,
+    formatMergeConfig<CustomGroupedBarConfig>(getOriginConfig(data), config, formatConfig),
+  );
 
   plot.render();
   return plot;
 };
 
-export default createSingleChart(createCustomGroupedBarPlot);
+export default createSingleChart<CustomGroupedBarConfig, DataItem[], CustomGroupedBar>(
+  createCustomGroupedBarPlot,
+  { getOriginConfig },
+);

--- a/packages/charts/src/utils/create-custom-grouped-bar-plot/index.ts
+++ b/packages/charts/src/utils/create-custom-grouped-bar-plot/index.ts
@@ -26,11 +26,11 @@ const createCustomGroupedBarPlot = ({
   dom,
   data,
   config = {},
-  formatConfig,
+  replaceConfig,
 }: PlotCreateProps<CustomGroupedBarConfig>) => {
   const plot = new CustomGroupedBar(
     dom,
-    formatMergeConfig<CustomGroupedBarConfig>(getOriginConfig(data), config, formatConfig),
+    formatMergeConfig<CustomGroupedBarConfig>(getOriginConfig(data), config, replaceConfig),
   );
 
   plot.render();

--- a/packages/charts/src/utils/create-custom-range-bar-plot/index.ts
+++ b/packages/charts/src/utils/create-custom-range-bar-plot/index.ts
@@ -24,11 +24,11 @@ const createCustomRangeBarPlot = ({
   dom,
   data,
   config = {},
-  formatConfig,
+  replaceConfig,
 }: PlotCreateProps<CustomRangeBarConfig>) => {
   const plot = new CustomRangeBar(
     dom,
-    formatMergeConfig<CustomRangeBarConfig>(getOriginConfig(data), config, formatConfig),
+    formatMergeConfig<CustomRangeBarConfig>(getOriginConfig(data), config, replaceConfig),
   );
 
   plot.render();

--- a/packages/charts/src/utils/create-custom-range-bar-plot/index.ts
+++ b/packages/charts/src/utils/create-custom-range-bar-plot/index.ts
@@ -4,29 +4,38 @@
  * @作者: 廖军
  * @Date: 2020-04-29 17:02:07
  * @LastEditors: 阮旭松
- * @LastEditTime: 2020-06-21 22:44:25
+ * @LastEditTime: 2020-07-04 18:49:02
  */
-import { PlotCreateProps, baseConfig, hideAxisConfig } from '../../config';
+import { PlotCreateProps, baseConfig, hideAxisConfig, DataItem } from '../../config';
 import CustomRangeBar, { CustomRangeBarConfig } from '../../g2components/CustomRangeBar';
-import { createSingleChart } from '../../baseUtils/chart';
+import { createSingleChart, formatMergeConfig } from '../../baseUtils/chart';
+
+/** 获得原始配置 */
+const getOriginConfig = (data: DataItem[]) => ({
+  ...baseConfig,
+  xAxis: hideAxisConfig,
+  yAxis: hideAxisConfig,
+  data,
+  padding: [0, 0, 10, 0],
+  color: 'l(0) 0:rgba(24, 137, 243, 1) 1:rgba(0, 210, 255, 1)',
+});
 
 const createCustomRangeBarPlot = ({
   dom,
   data,
   config = {},
+  formatConfig,
 }: PlotCreateProps<CustomRangeBarConfig>) => {
-  const plot = new CustomRangeBar(dom, {
-    ...baseConfig,
-    xAxis: hideAxisConfig,
-    yAxis: hideAxisConfig,
-    data,
-    padding: [0, 0, 10, 0],
-    color: 'l(0) 0:rgba(24, 137, 243, 1) 1:rgba(0, 210, 255, 1)',
-    ...config,
-  });
+  const plot = new CustomRangeBar(
+    dom,
+    formatMergeConfig<CustomRangeBarConfig>(getOriginConfig(data), config, formatConfig),
+  );
 
   plot.render();
   return plot;
 };
 
-export default createSingleChart(createCustomRangeBarPlot);
+export default createSingleChart<CustomRangeBarConfig, DataItem[], CustomRangeBar>(
+  createCustomRangeBarPlot,
+  { getOriginConfig },
+);

--- a/packages/charts/src/utils/create-donut-plot/index.ts
+++ b/packages/charts/src/utils/create-donut-plot/index.ts
@@ -157,9 +157,9 @@ const highlightDount = (
 const getOriginConfig = (
   data: number | DataItem[],
   config?: CustomRingConfig,
-  formatConfig?: (config: CustomRingConfig) => CustomRingConfig,
+  replaceConfig?: (config: CustomRingConfig) => CustomRingConfig,
 ) => {
-  const transformedConfig = formatConfig ? formatConfig(config || {}) : config;
+  const transformedConfig = replaceConfig ? replaceConfig(config || {}) : config;
   const donutThemeConfig = themeConfig.donutConfig;
   const plotConfig = getDonutConfig(data, transformedConfig);
   const newData = singleDonutFormatData(data as number, transformedConfig);
@@ -198,15 +198,15 @@ const getOriginConfig = (
   } as RingConfig;
 };
 
-const createDonutPlot = ({ dom, data, config, formatConfig }: RingPlotCreateProps) => {
+const createDonutPlot = ({ dom, data, config, replaceConfig }: RingPlotCreateProps) => {
   const { isSingle, bordered, titleName, hoverHighlight, ...restConfig } = config || {};
 
   const donutChart = new Donut(
     dom,
     formatMergeConfig<RingConfig>(
-      getOriginConfig(data, config, formatConfig),
+      getOriginConfig(data, config, replaceConfig),
       restConfig,
-      formatConfig,
+      replaceConfig,
     ),
   );
 

--- a/packages/charts/src/utils/create-donut-rose-plot/index.ts
+++ b/packages/charts/src/utils/create-donut-rose-plot/index.ts
@@ -4,19 +4,33 @@
  * @作者: 阮旭松
  * @Date: 2020-04-27 14:53:56
  * @LastEditors: 阮旭松
- * @LastEditTime: 2020-06-22 10:11:54
+ * @LastEditTime: 2020-07-04 16:02:33
  */
-import { PlotCreateProps } from '../../config';
+import { PlotCreateProps, DataItem } from '../../config';
 import CustomDonutRose, { CustomRoseConfig } from '../../g2components/CustomDonutRose';
-import { createSingleChart } from '../../baseUtils/chart';
+import { createSingleChart, formatMergeConfig } from '../../baseUtils/chart';
 
-const createDonutRosePlot = ({ dom, data, config }: PlotCreateProps<CustomRoseConfig>) => {
-  const rosePlot = new CustomDonutRose(dom, {
-    data,
-    ...config,
-  });
+const createDonutRosePlot = ({
+  dom,
+  data,
+  config = {},
+  formatConfig,
+}: PlotCreateProps<CustomRoseConfig>) => {
+  const rosePlot = new CustomDonutRose(
+    dom,
+    formatMergeConfig<CustomRoseConfig>(
+      {
+        data,
+      },
+      config,
+      formatConfig,
+    ),
+  );
+
   rosePlot.render();
   return rosePlot;
 };
 
-export default createSingleChart(createDonutRosePlot);
+export default createSingleChart<CustomRoseConfig, DataItem[], CustomDonutRose>(
+  createDonutRosePlot,
+);

--- a/packages/charts/src/utils/create-donut-rose-plot/index.ts
+++ b/packages/charts/src/utils/create-donut-rose-plot/index.ts
@@ -14,7 +14,7 @@ const createDonutRosePlot = ({
   dom,
   data,
   config = {},
-  formatConfig,
+  replaceConfig,
 }: PlotCreateProps<CustomRoseConfig>) => {
   const rosePlot = new CustomDonutRose(
     dom,
@@ -23,7 +23,7 @@ const createDonutRosePlot = ({
         data,
       },
       config,
-      formatConfig,
+      replaceConfig,
     ),
   );
 

--- a/packages/charts/src/utils/create-dual-line-plot/index.ts
+++ b/packages/charts/src/utils/create-dual-line-plot/index.ts
@@ -58,9 +58,9 @@ const getDualLineConfig = (data: DataItem[][], config?: CustomDualLineConfig) =>
 const getOriginConfig = (
   data: DataItem[][],
   config?: CustomDualLineConfig,
-  formatConfig?: (config: CustomDualLineConfig) => CustomDualLineConfig,
+  replaceConfig?: (config: CustomDualLineConfig) => CustomDualLineConfig,
 ) => {
-  const transformedConfig = formatConfig ? formatConfig(config || {}) : config;
+  const transformedConfig = replaceConfig ? replaceConfig(config || {}) : config;
   const plotConfig = getDualLineConfig(data, transformedConfig);
   return {
     ...baseComboConfig,
@@ -71,15 +71,15 @@ const getOriginConfig = (
   };
 };
 
-const createDualLinePlot = ({ dom, data, config = {}, formatConfig }: DualLineCreateProps) => {
+const createDualLinePlot = ({ dom, data, config = {}, replaceConfig }: DualLineCreateProps) => {
   const { color, isSingleAxis, ...restConfig } = config;
 
   const plot = new DualLine(
     dom,
     formatMergeConfig<DualLineConfig>(
-      getOriginConfig(data, config, formatConfig),
+      getOriginConfig(data, config, replaceConfig),
       restConfig,
-      formatConfig,
+      replaceConfig,
     ),
   );
 

--- a/packages/charts/src/utils/create-group-column-plot/index.ts
+++ b/packages/charts/src/utils/create-group-column-plot/index.ts
@@ -4,25 +4,40 @@
  * @作者: 廖军
  * @Date: 2020-04-27 16:43:00
  * @LastEditors: 阮旭松
- * @LastEditTime: 2020-06-22 10:12:01
+ * @LastEditTime: 2020-07-04 18:58:11
  */
 import { GroupedColumn, GroupedColumnConfig } from '@antv/g2plot';
-import { baseConfig, PlotCreateProps, colors } from '../../config';
-import { createSingleChart } from '../../baseUtils/chart';
+import { baseConfig, PlotCreateProps, colors, DataItem } from '../../config';
+import { createSingleChart, formatMergeConfig } from '../../baseUtils/chart';
 
-const createGroupColumnPlot = ({ dom, data, config }: PlotCreateProps<GroupedColumnConfig>) => {
-  const plot = new GroupedColumn(dom, {
-    ...baseConfig,
-    xField: 'date',
-    yField: 'value',
-    groupField: 'type',
-    data,
-    color: colors,
-    ...config,
-  });
+/** 获得原始配置 */
+const getOriginConfig = (data: DataItem[]) => ({
+  ...baseConfig,
+  xField: 'date',
+  yField: 'value',
+  groupField: 'type',
+  data,
+  color: colors,
+});
+
+const createGroupColumnPlot = ({
+  dom,
+  data,
+  config = {},
+  formatConfig,
+}: PlotCreateProps<Partial<GroupedColumnConfig>>) => {
+  const plot = new GroupedColumn(
+    dom,
+    formatMergeConfig<GroupedColumnConfig>(getOriginConfig(data), config, formatConfig),
+  );
 
   plot.render();
   return plot;
 };
 
-export default createSingleChart(createGroupColumnPlot);
+export default createSingleChart<Partial<GroupedColumnConfig>, DataItem[], GroupedColumn>(
+  createGroupColumnPlot,
+  {
+    getOriginConfig,
+  },
+);

--- a/packages/charts/src/utils/create-group-column-plot/index.ts
+++ b/packages/charts/src/utils/create-group-column-plot/index.ts
@@ -24,11 +24,11 @@ const createGroupColumnPlot = ({
   dom,
   data,
   config = {},
-  formatConfig,
+  replaceConfig,
 }: PlotCreateProps<Partial<GroupedColumnConfig>>) => {
   const plot = new GroupedColumn(
     dom,
-    formatMergeConfig<GroupedColumnConfig>(getOriginConfig(data), config, formatConfig),
+    formatMergeConfig<GroupedColumnConfig>(getOriginConfig(data), config, replaceConfig),
   );
 
   plot.render();

--- a/packages/charts/src/utils/create-grouped-column-line-plot/index.ts
+++ b/packages/charts/src/utils/create-grouped-column-line-plot/index.ts
@@ -30,9 +30,9 @@ type GroupedColumnLineCreateProps = Merge<
 const getOriginConfig = (
   data: DataItem[][],
   config?: CustomGroupedColumnLineConfig,
-  formatConfig?: (config: CustomGroupedColumnLineConfig) => CustomGroupedColumnLineConfig,
+  replaceConfig?: (config: CustomGroupedColumnLineConfig) => CustomGroupedColumnLineConfig,
 ) => {
-  const transformedConfig = formatConfig ? formatConfig(config || {}) : config;
+  const transformedConfig = replaceConfig ? replaceConfig(config || {}) : config;
   const plotConfig = getColumnLineConfig(data, transformedConfig);
   return {
     ...baseComboConfig,
@@ -52,15 +52,15 @@ const createGroupedColumnLinePlot = ({
   dom,
   data,
   config = {},
-  formatConfig,
+  replaceConfig,
 }: GroupedColumnLineCreateProps) => {
   const { isSingleAxis, ...restConfig } = config || {};
   const plot = new GroupedColumnLine(
     dom,
     formatMergeConfig<GroupedColumnLineConfig>(
-      getOriginConfig(data, config, formatConfig),
+      getOriginConfig(data, config, replaceConfig),
       restConfig,
-      formatConfig,
+      replaceConfig,
     ),
   );
 

--- a/packages/charts/src/utils/create-line-plot/index.ts
+++ b/packages/charts/src/utils/create-line-plot/index.ts
@@ -21,10 +21,10 @@ const getOriginConfig = (data: DataItem[]) => ({
   color: colors,
 });
 
-const createLinePlot = ({ dom, data, config = {}, formatConfig }: PlotCreateProps<LineConfig>) => {
+const createLinePlot = ({ dom, data, config = {}, replaceConfig }: PlotCreateProps<LineConfig>) => {
   const plot = new Line(
     dom,
-    formatMergeConfig<LineConfig>(getOriginConfig(data), config, formatConfig),
+    formatMergeConfig<LineConfig>(getOriginConfig(data), config, replaceConfig),
   );
 
   plot.render();

--- a/packages/charts/src/utils/create-line-plot/index.ts
+++ b/packages/charts/src/utils/create-line-plot/index.ts
@@ -4,26 +4,31 @@
  * @作者: 廖军
  * @Date: 2020-04-27 13:56:23
  * @LastEditors: 阮旭松
- * @LastEditTime: 2020-06-22 10:12:16
+ * @LastEditTime: 2020-07-04 19:00:39
  */
 import { Line, LineConfig } from '@antv/g2plot';
-import { PlotCreateProps, baseConfig, colors, basePoint } from '../../config';
-import { createSingleChart } from '../../baseUtils/chart';
+import { PlotCreateProps, baseConfig, colors, basePoint, DataItem } from '../../config';
+import { createSingleChart, formatMergeConfig } from '../../baseUtils/chart';
 
-const createLinePlot = ({ dom, data, config = {} }: PlotCreateProps<LineConfig>) => {
-  const plot = new Line(dom, {
-    ...baseConfig,
-    data,
-    lineStyle: {
-      lineWidth: 1,
-    },
-    point: basePoint,
-    color: colors,
-    ...config,
-  });
+/** 获得原始配置 */
+const getOriginConfig = (data: DataItem[]) => ({
+  ...baseConfig,
+  data,
+  lineStyle: {
+    lineWidth: 1,
+  },
+  point: basePoint,
+  color: colors,
+});
+
+const createLinePlot = ({ dom, data, config = {}, formatConfig }: PlotCreateProps<LineConfig>) => {
+  const plot = new Line(
+    dom,
+    formatMergeConfig<LineConfig>(getOriginConfig(data), config, formatConfig),
+  );
 
   plot.render();
   return plot;
 };
 
-export default createSingleChart(createLinePlot);
+export default createSingleChart<LineConfig, DataItem[], Line>(createLinePlot, { getOriginConfig });

--- a/packages/charts/src/utils/create-liquid-plot/index.ts
+++ b/packages/charts/src/utils/create-liquid-plot/index.ts
@@ -25,9 +25,9 @@ export type LiquidPlotCreateProps = Merge<PlotCreateProps<CustomLiquidConfig>, {
 const getOriginConfig = (
   data: number,
   config?: CustomLiquidConfig,
-  formatConfig?: (config: CustomLiquidConfig) => CustomLiquidConfig,
+  replaceConfig?: (config: CustomLiquidConfig) => CustomLiquidConfig,
 ) => {
-  const transformedConfig = formatConfig ? formatConfig(config || {}) : config;
+  const transformedConfig = replaceConfig ? replaceConfig(config || {}) : config;
   const { fixedNumber = 0, suffix = '%' } = transformedConfig || {};
   const liquidThemeConfig = themeConfig.liquidConfig;
   return {
@@ -51,14 +51,14 @@ const getOriginConfig = (
   } as LiquidConfig;
 };
 
-const createLiquidPlot = ({ dom, data, config, formatConfig }: LiquidPlotCreateProps) => {
+const createLiquidPlot = ({ dom, data, config, replaceConfig }: LiquidPlotCreateProps) => {
   const { fixedNumber, suffix, ...restConfig } = config || {};
   const liquidPlot = new Liquid(
     dom,
     formatMergeConfig<LiquidConfig>(
-      getOriginConfig(data, config, formatConfig),
+      getOriginConfig(data, config, replaceConfig),
       restConfig,
-      formatConfig,
+      replaceConfig,
     ),
   );
 

--- a/packages/charts/src/utils/create-liquid-plot/index.ts
+++ b/packages/charts/src/utils/create-liquid-plot/index.ts
@@ -4,11 +4,11 @@
  * @作者: 阮旭松
  * @Date: 2020-04-27 14:53:56
  * @LastEditors: 阮旭松
- * @LastEditTime: 2020-06-20 21:12:20
+ * @LastEditTime: 2020-07-04 20:01:38
  */
 import { Liquid, LiquidConfig } from '@antv/g2plot';
 import { PlotCreateProps, basePieConfig, themeConfig } from '../../config';
-import { createSingleChart } from '../../baseUtils/chart';
+import { createSingleChart, formatMergeConfig } from '../../baseUtils/chart';
 
 type Merge<M, N> = Omit<M, Extract<keyof M, keyof N>> & N;
 
@@ -21,10 +21,16 @@ export interface CustomLiquidConfig extends Partial<LiquidConfig> {
 
 export type LiquidPlotCreateProps = Merge<PlotCreateProps<CustomLiquidConfig>, { data: number }>;
 
-const createLiquidPlot = ({ dom, data, config }: LiquidPlotCreateProps) => {
-  const { fixedNumber = 0, suffix = '%' } = config || {};
+/** 获得原始配置 */
+const getOriginConfig = (
+  data: number,
+  config?: CustomLiquidConfig,
+  formatConfig?: (config: CustomLiquidConfig) => CustomLiquidConfig,
+) => {
+  const transformedConfig = formatConfig ? formatConfig(config || {}) : config;
+  const { fixedNumber = 0, suffix = '%' } = transformedConfig || {};
   const liquidThemeConfig = themeConfig.liquidConfig;
-  const liquidPlot = new Liquid(dom, {
+  return {
     ...basePieConfig,
     color: '#10ADF9',
     padding: [0, 0, 10, 0],
@@ -42,10 +48,24 @@ const createLiquidPlot = ({ dom, data, config }: LiquidPlotCreateProps) => {
       },
       formatter: value => value.toFixed(fixedNumber) + suffix,
     },
-    ...config,
-  });
+  } as LiquidConfig;
+};
+
+const createLiquidPlot = ({ dom, data, config, formatConfig }: LiquidPlotCreateProps) => {
+  const { fixedNumber, suffix, ...restConfig } = config || {};
+  const liquidPlot = new Liquid(
+    dom,
+    formatMergeConfig<LiquidConfig>(
+      getOriginConfig(data, config, formatConfig),
+      restConfig,
+      formatConfig,
+    ),
+  );
+
   liquidPlot.render();
   return liquidPlot;
 };
 
-export default createSingleChart(createLiquidPlot);
+export default createSingleChart<CustomLiquidConfig, number, Liquid>(createLiquidPlot, {
+  getOriginConfig,
+});

--- a/packages/charts/src/utils/create-radar-plot/index.ts
+++ b/packages/charts/src/utils/create-radar-plot/index.ts
@@ -4,14 +4,15 @@
  * @作者: 阮旭松
  * @Date: 2020-04-27 14:53:56
  * @LastEditors: 阮旭松
- * @LastEditTime: 2020-06-22 10:12:29
+ * @LastEditTime: 2020-07-04 19:05:08
  */
 import { Radar, RadarConfig } from '@antv/g2plot';
-import { PlotCreateProps, basePieConfig } from '../../config';
-import { createSingleChart } from '../../baseUtils/chart';
+import { PlotCreateProps, basePieConfig, DataItem } from '../../config';
+import { createSingleChart, formatMergeConfig } from '../../baseUtils/chart';
 
-const createRadarPlot = ({ dom, data, config }: PlotCreateProps<Partial<RadarConfig>>) => {
-  const radarPlot = new Radar(dom, {
+/** 获得原始配置 */
+const getOriginConfig = (data: DataItem[]) =>
+  ({
     ...basePieConfig,
     data,
     angleField: 'item',
@@ -55,10 +56,23 @@ const createRadarPlot = ({ dom, data, config }: PlotCreateProps<Partial<RadarCon
       visible: false,
       shape: 'circle',
     },
-    ...config,
-  });
+  } as RadarConfig);
+
+const createRadarPlot = ({
+  dom,
+  data,
+  config = {},
+  formatConfig,
+}: PlotCreateProps<Partial<RadarConfig>>) => {
+  const radarPlot = new Radar(
+    dom,
+    formatMergeConfig<RadarConfig>(getOriginConfig(data), config, formatConfig),
+  );
+
   radarPlot.render();
   return radarPlot;
 };
 
-export default createSingleChart(createRadarPlot);
+export default createSingleChart<Partial<RadarConfig>, DataItem[], Radar>(createRadarPlot, {
+  getOriginConfig,
+});

--- a/packages/charts/src/utils/create-radar-plot/index.ts
+++ b/packages/charts/src/utils/create-radar-plot/index.ts
@@ -62,11 +62,11 @@ const createRadarPlot = ({
   dom,
   data,
   config = {},
-  formatConfig,
+  replaceConfig,
 }: PlotCreateProps<Partial<RadarConfig>>) => {
   const radarPlot = new Radar(
     dom,
-    formatMergeConfig<RadarConfig>(getOriginConfig(data), config, formatConfig),
+    formatMergeConfig<RadarConfig>(getOriginConfig(data), config, replaceConfig),
   );
 
   radarPlot.render();

--- a/packages/charts/src/utils/create-radial-stack-plot/index.ts
+++ b/packages/charts/src/utils/create-radial-stack-plot/index.ts
@@ -14,7 +14,7 @@ const createRadialStackPlot = ({
   dom,
   data,
   config = {},
-  formatConfig,
+  replaceConfig,
 }: PlotCreateProps<CustomRadialConfig>) => {
   const radialStackPlot = new CustomRadialStack(
     dom,
@@ -23,7 +23,7 @@ const createRadialStackPlot = ({
         data,
       },
       config,
-      formatConfig,
+      replaceConfig,
     ),
   );
 

--- a/packages/charts/src/utils/create-radial-stack-plot/index.ts
+++ b/packages/charts/src/utils/create-radial-stack-plot/index.ts
@@ -4,19 +4,33 @@
  * @作者: 阮旭松
  * @Date: 2020-04-27 14:53:56
  * @LastEditors: 阮旭松
- * @LastEditTime: 2020-06-22 10:12:36
+ * @LastEditTime: 2020-07-04 19:05:36
  */
-import { PlotCreateProps } from '../../config';
+import { PlotCreateProps, DataItem } from '../../config';
 import CustomRadialStack, { CustomRadialConfig } from '../../g2components/CustomRadialStack';
-import { createSingleChart } from '../../baseUtils/chart';
+import { createSingleChart, formatMergeConfig } from '../../baseUtils/chart';
 
-const createRadialStackPlot = ({ dom, data, config }: PlotCreateProps<CustomRadialConfig>) => {
-  const radialStackPlot = new CustomRadialStack(dom, {
-    data,
-    ...config,
-  });
+const createRadialStackPlot = ({
+  dom,
+  data,
+  config = {},
+  formatConfig,
+}: PlotCreateProps<CustomRadialConfig>) => {
+  const radialStackPlot = new CustomRadialStack(
+    dom,
+    formatMergeConfig<CustomRadialConfig>(
+      {
+        data,
+      },
+      config,
+      formatConfig,
+    ),
+  );
+
   radialStackPlot.render();
   return radialStackPlot;
 };
 
-export default createSingleChart(createRadialStackPlot);
+export default createSingleChart<CustomRadialConfig, DataItem[], CustomRadialStack>(
+  createRadialStackPlot,
+);

--- a/packages/charts/src/utils/create-range-column-plot/index.ts
+++ b/packages/charts/src/utils/create-range-column-plot/index.ts
@@ -4,23 +4,36 @@
  * @作者: 廖军
  * @Date: 2020-04-27 17:11:09
  * @LastEditors: 阮旭松
- * @LastEditTime: 2020-06-22 10:12:43
+ * @LastEditTime: 2020-07-04 19:06:24
  */
 import { RangeColumn, RangeColumnConfig } from '@antv/g2plot';
-import { baseConfig, PlotCreateProps, colors } from '../../config';
-import { createSingleChart } from '../../baseUtils/chart';
+import { baseConfig, PlotCreateProps, colors, DataItem } from '../../config';
+import { createSingleChart, formatMergeConfig } from '../../baseUtils/chart';
 
-const createRangeColumnPlot = ({ dom, data, config }: PlotCreateProps<RangeColumnConfig>) => {
-  const plot = new RangeColumn(dom, {
-    ...baseConfig,
-    label: { visible: false },
-    data,
-    color: colors[0],
-    ...config,
-  });
+/** 获得原始配置 */
+const getOriginConfig = (data: DataItem[]) => ({
+  ...baseConfig,
+  label: { visible: false },
+  data,
+  color: colors[0],
+});
+
+const createRangeColumnPlot = ({
+  dom,
+  data,
+  config = {},
+  formatConfig,
+}: PlotCreateProps<RangeColumnConfig>) => {
+  const plot = new RangeColumn(
+    dom,
+    formatMergeConfig<RangeColumnConfig>(getOriginConfig(data), config, formatConfig),
+  );
 
   plot.render();
   return plot;
 };
 
-export default createSingleChart(createRangeColumnPlot);
+export default createSingleChart<RangeColumnConfig, DataItem[], RangeColumn>(
+  createRangeColumnPlot,
+  { getOriginConfig },
+);

--- a/packages/charts/src/utils/create-range-column-plot/index.ts
+++ b/packages/charts/src/utils/create-range-column-plot/index.ts
@@ -22,11 +22,11 @@ const createRangeColumnPlot = ({
   dom,
   data,
   config = {},
-  formatConfig,
+  replaceConfig,
 }: PlotCreateProps<RangeColumnConfig>) => {
   const plot = new RangeColumn(
     dom,
-    formatMergeConfig<RangeColumnConfig>(getOriginConfig(data), config, formatConfig),
+    formatMergeConfig<RangeColumnConfig>(getOriginConfig(data), config, replaceConfig),
   );
 
   plot.render();

--- a/packages/charts/src/utils/create-scatter-plot/index.ts
+++ b/packages/charts/src/utils/create-scatter-plot/index.ts
@@ -131,9 +131,9 @@ const getScatterConfig = (data: DataItem[], config?: CustomBubbleConfig) => {
 const getOriginConfig = (
   data: DataItem[],
   config?: CustomBubbleConfig,
-  formatConfig?: (config: CustomBubbleConfig) => CustomBubbleConfig,
+  replaceConfig?: (config: CustomBubbleConfig) => CustomBubbleConfig,
 ) => {
-  const transformedConfig = formatConfig ? formatConfig(config || {}) : config;
+  const transformedConfig = replaceConfig ? replaceConfig(config || {}) : config;
   const { xField = 'date', yField = 'type', sizeField = 'value' } = transformedConfig || {};
   const modifiedData = scatterFormatData(data, transformedConfig);
   const scatterConfig = getScatterConfig(data, transformedConfig);
@@ -171,16 +171,16 @@ const createScatterPlot = ({
   dom,
   data,
   config,
-  formatConfig,
+  replaceConfig,
 }: PlotCreateProps<CustomBubbleConfig>) => {
   const { yNameFormatter, ...restConfig } = config || {};
 
   const bubblePlot = new Bubble(
     dom,
     formatMergeConfig<BubbleConfig>(
-      getOriginConfig(data, config, formatConfig),
+      getOriginConfig(data, config, replaceConfig),
       restConfig,
-      formatConfig,
+      replaceConfig,
     ),
   );
   bubblePlot.render();

--- a/packages/charts/src/utils/create-stack-area-plot/index.ts
+++ b/packages/charts/src/utils/create-stack-area-plot/index.ts
@@ -25,11 +25,11 @@ const createStackAreaPlot = ({
   dom,
   data,
   config = {},
-  formatConfig,
+  replaceConfig,
 }: PlotCreateProps<Partial<StackAreaConfig>>) => {
   const plot = new StackedArea(
     dom,
-    formatMergeConfig<StackAreaConfig>(getOriginConfig(data), config, formatConfig),
+    formatMergeConfig<StackAreaConfig>(getOriginConfig(data), config, replaceConfig),
   );
 
   plot.render();

--- a/packages/charts/src/utils/create-stack-area-plot/index.ts
+++ b/packages/charts/src/utils/create-stack-area-plot/index.ts
@@ -4,26 +4,39 @@
  * @作者: 阮旭松
  * @Date: 2020-04-29 14:52:09
  * @LastEditors: 阮旭松
- * @LastEditTime: 2020-06-20 21:13:49
+ * @LastEditTime: 2020-07-04 19:11:14
  */
 
 import { StackedArea, StackAreaConfig } from '@antv/g2plot';
-import { PlotCreateProps, baseConfig } from '../../config';
-import { createSingleChart } from '../../baseUtils/chart';
+import { PlotCreateProps, baseConfig, DataItem } from '../../config';
+import { createSingleChart, formatMergeConfig } from '../../baseUtils/chart';
 
-const createStackAreaPlot = ({ dom, data, config }: PlotCreateProps<StackAreaConfig>) => {
-  const plot = new StackedArea(dom, {
-    ...baseConfig,
-    data,
-    xField: 'date',
-    yField: 'value',
-    stackField: 'type',
-    color: ['#FEB01E', '#EC6725', '#38B03B'],
-    ...config,
-  });
+/** 获得原始配置 */
+const getOriginConfig = (data: DataItem[]) => ({
+  ...baseConfig,
+  data,
+  xField: 'date',
+  yField: 'value',
+  stackField: 'type',
+  color: ['#FEB01E', '#EC6725', '#38B03B'],
+});
+
+const createStackAreaPlot = ({
+  dom,
+  data,
+  config = {},
+  formatConfig,
+}: PlotCreateProps<Partial<StackAreaConfig>>) => {
+  const plot = new StackedArea(
+    dom,
+    formatMergeConfig<StackAreaConfig>(getOriginConfig(data), config, formatConfig),
+  );
 
   plot.render();
   return plot;
 };
 
-export default createSingleChart(createStackAreaPlot);
+export default createSingleChart<Partial<StackAreaConfig>, DataItem[], StackedArea>(
+  createStackAreaPlot,
+  { getOriginConfig },
+);

--- a/packages/charts/src/utils/create-stack-column-plot/index.ts
+++ b/packages/charts/src/utils/create-stack-column-plot/index.ts
@@ -4,25 +4,38 @@
  * @作者: 廖军
  * @Date: 2020-04-27 17:00:54
  * @LastEditors: 阮旭松
- * @LastEditTime: 2020-06-20 21:14:20
+ * @LastEditTime: 2020-07-04 19:11:55
  */
 import { StackedColumn, StackedColumnConfig } from '@antv/g2plot';
-import { baseConfig, PlotCreateProps, colors } from '../../config';
-import { createSingleChart } from '../../baseUtils/chart';
+import { baseConfig, PlotCreateProps, colors, DataItem } from '../../config';
+import { createSingleChart, formatMergeConfig } from '../../baseUtils/chart';
 
-const createStackColumnPlot = ({ dom, data, config }: PlotCreateProps<StackedColumnConfig>) => {
-  const plot = new StackedColumn(dom, {
-    ...baseConfig,
-    xField: 'date',
-    yField: 'value',
-    stackField: 'type',
-    data,
-    color: colors,
-    ...config,
-  });
+/** 获得原始配置 */
+const getOriginConfig = (data: DataItem[]) => ({
+  ...baseConfig,
+  xField: 'date',
+  yField: 'value',
+  stackField: 'type',
+  data,
+  color: colors,
+});
+
+const createStackColumnPlot = ({
+  dom,
+  data,
+  config = {},
+  formatConfig,
+}: PlotCreateProps<Partial<StackedColumnConfig>>) => {
+  const plot = new StackedColumn(
+    dom,
+    formatMergeConfig<StackedColumnConfig>(getOriginConfig(data), config, formatConfig),
+  );
 
   plot.render();
   return plot;
 };
 
-export default createSingleChart(createStackColumnPlot);
+export default createSingleChart<Partial<StackedColumnConfig>, DataItem[], StackedColumn>(
+  createStackColumnPlot,
+  { getOriginConfig },
+);

--- a/packages/charts/src/utils/create-stack-column-plot/index.ts
+++ b/packages/charts/src/utils/create-stack-column-plot/index.ts
@@ -24,11 +24,11 @@ const createStackColumnPlot = ({
   dom,
   data,
   config = {},
-  formatConfig,
+  replaceConfig,
 }: PlotCreateProps<Partial<StackedColumnConfig>>) => {
   const plot = new StackedColumn(
     dom,
-    formatMergeConfig<StackedColumnConfig>(getOriginConfig(data), config, formatConfig),
+    formatMergeConfig<StackedColumnConfig>(getOriginConfig(data), config, replaceConfig),
   );
 
   plot.render();

--- a/packages/charts/src/utils/create-stack-rose-plot/index.ts
+++ b/packages/charts/src/utils/create-stack-rose-plot/index.ts
@@ -4,9 +4,10 @@
  * @作者: 阮旭松
  * @Date: 2020-04-27 14:53:56
  * @LastEditors: 阮旭松
- * @LastEditTime: 2020-06-24 10:37:30
+ * @LastEditTime: 2020-07-04 19:49:11
  */
 import { StackedRose, StackedRoseConfig } from '@antv/g2plot';
+import { isEmpty } from 'lodash-es';
 import {
   PlotCreateProps,
   basePieConfig,
@@ -15,17 +16,17 @@ import {
   DataItem,
   themeConfig,
 } from '../../config';
-import { createSingleChart } from '../../baseUtils/chart';
+import { createSingleChart, formatMergeConfig } from '../../baseUtils/chart';
 
 type Merge<M, N> = Omit<M, Extract<keyof M, keyof N>> & N;
 
 export type CustomStackedRoseConfig = Merge<
-  StackedRoseConfig,
+  Partial<StackedRoseConfig>,
   {
     // 是否螺旋上升且空心
     isSpiral?: boolean;
     // 扇形颜色
-    color?: string | string[];
+    color?: string | string[] | {};
   }
 >;
 
@@ -87,9 +88,9 @@ const stackRoseFormatConfig = (data: DataItem[], config?: CustomStackedRoseConfi
   const { color, stackField = 'type', isSpiral = false } = config || {};
   const stackCount = [...new Set(data.map(item => item[stackField]))].length;
   let colorArr = ['#00BBFF', '#A13ED6', '#EC6725', '#FEB01E'];
-  if (color) {
+  if (color && !isEmpty(color)) {
     // 转换颜色为数组
-    colorArr = Array.isArray(color) ? color : [color];
+    colorArr = Array.isArray(color) ? color : ([color] as string[]);
   }
   // 螺旋相关配置
   if (isSpiral) {
@@ -100,13 +101,19 @@ const stackRoseFormatConfig = (data: DataItem[], config?: CustomStackedRoseConfi
   };
 };
 
-const createStackRosePlot = ({ dom, data, config }: PlotCreateProps<CustomStackedRoseConfig>) => {
-  const { categoryField = 'category', radiusField = 'value', stackField = 'type' } = config || {};
-  const formatedData = stackRoseFormatData(data, config);
+/** 获得原始配置 */
+const getOriginConfig = (
+  data: DataItem[],
+  config?: CustomStackedRoseConfig,
+  formatConfig?: (config: CustomStackedRoseConfig) => CustomStackedRoseConfig,
+) => {
+  const transformedConfig = formatConfig ? formatConfig(config || {}) : config;
+  const { categoryField = 'category', radiusField = 'value', stackField = 'type' } =
+    transformedConfig || {};
+  const formatedData = stackRoseFormatData(data, transformedConfig);
 
-  const formatedConfig = stackRoseFormatConfig(data, config);
-
-  const rosePlot = new StackedRose(dom, {
+  const formatedConfig = stackRoseFormatConfig(data, transformedConfig);
+  return {
     ...basePieConfig,
     padding: [20, 50, 50, 50],
     radius: 1,
@@ -152,15 +159,34 @@ const createStackRosePlot = ({ dom, data, config }: PlotCreateProps<CustomStacke
       stroke: 'rgba(255, 255, 255, 0)',
       fillOpacity: 1,
     },
-    ...config,
     ...formatedConfig,
-  });
+  } as StackedRoseConfig;
+};
+
+const createStackRosePlot = ({
+  dom,
+  data,
+  config,
+  formatConfig,
+}: PlotCreateProps<CustomStackedRoseConfig>) => {
+  const { isSpiral, color, ...restConfig } = config || {};
+
+  const rosePlot = new StackedRose(
+    dom,
+    formatMergeConfig<StackedRoseConfig>(
+      getOriginConfig(data, config, formatConfig),
+      restConfig,
+      formatConfig,
+    ),
+  );
 
   rosePlot.render();
   return rosePlot;
 };
 
-export default createSingleChart(createStackRosePlot, {
-  dataFormat: stackRoseFormatData,
-  configFormat: stackRoseFormatConfig,
-});
+export default createSingleChart<CustomStackedRoseConfig, DataItem[], StackedRose>(
+  createStackRosePlot,
+  {
+    getOriginConfig,
+  },
+);

--- a/packages/charts/src/utils/create-stack-rose-plot/index.ts
+++ b/packages/charts/src/utils/create-stack-rose-plot/index.ts
@@ -105,9 +105,9 @@ const stackRoseFormatConfig = (data: DataItem[], config?: CustomStackedRoseConfi
 const getOriginConfig = (
   data: DataItem[],
   config?: CustomStackedRoseConfig,
-  formatConfig?: (config: CustomStackedRoseConfig) => CustomStackedRoseConfig,
+  replaceConfig?: (config: CustomStackedRoseConfig) => CustomStackedRoseConfig,
 ) => {
-  const transformedConfig = formatConfig ? formatConfig(config || {}) : config;
+  const transformedConfig = replaceConfig ? replaceConfig(config || {}) : config;
   const { categoryField = 'category', radiusField = 'value', stackField = 'type' } =
     transformedConfig || {};
   const formatedData = stackRoseFormatData(data, transformedConfig);
@@ -167,16 +167,16 @@ const createStackRosePlot = ({
   dom,
   data,
   config,
-  formatConfig,
+  replaceConfig,
 }: PlotCreateProps<CustomStackedRoseConfig>) => {
   const { isSpiral, color, ...restConfig } = config || {};
 
   const rosePlot = new StackedRose(
     dom,
     formatMergeConfig<StackedRoseConfig>(
-      getOriginConfig(data, config, formatConfig),
+      getOriginConfig(data, config, replaceConfig),
       restConfig,
-      formatConfig,
+      replaceConfig,
     ),
   );
 

--- a/packages/charts/src/utils/create-waterfall-plot/index.ts
+++ b/packages/charts/src/utils/create-waterfall-plot/index.ts
@@ -27,11 +27,11 @@ const createWaterfallPlot = ({
   dom,
   data,
   config = {},
-  formatConfig,
+  replaceConfig,
 }: PlotCreateProps<Partial<WaterfallConfig>>) => {
   const plot = new Waterfall(
     dom,
-    formatMergeConfig<WaterfallConfig>(getOriginConfig(data), config, formatConfig),
+    formatMergeConfig<WaterfallConfig>(getOriginConfig(data), config, replaceConfig),
   );
 
   plot.render();

--- a/packages/charts/src/utils/create-waterfall-plot/index.ts
+++ b/packages/charts/src/utils/create-waterfall-plot/index.ts
@@ -4,28 +4,41 @@
  * @作者: 廖军
  * @Date: 2020-04-28 09:46:33
  * @LastEditors: 阮旭松
- * @LastEditTime: 2020-06-22 10:13:36
+ * @LastEditTime: 2020-07-04 19:17:45
  */
 import { Waterfall, WaterfallConfig } from '@antv/g2plot';
-import { baseConfig, PlotCreateProps } from '../../config';
-import { createSingleChart } from '../../baseUtils/chart';
+import { baseConfig, PlotCreateProps, DataItem } from '../../config';
+import { createSingleChart, formatMergeConfig } from '../../baseUtils/chart';
 
-const createWaterfallPlot = ({ dom, data, config }: PlotCreateProps<WaterfallConfig>) => {
-  const plot = new Waterfall(dom, {
-    ...baseConfig,
-    data,
-    label: { visible: false },
-    showTotal: { visible: false, label: '' },
-    color: {
-      rising: 'rgba(216, 30, 25, 1)',
-      falling: 'rgba(73, 213, 18, 1)',
-      total: 'rgba(73, 213, 18, 0)',
-    },
-    ...config,
-  });
+/** 获得原始配置 */
+const getOriginConfig = (data: DataItem[]) => ({
+  ...baseConfig,
+  data,
+  label: { visible: false },
+  showTotal: { visible: false, label: '' },
+  color: {
+    rising: 'rgba(216, 30, 25, 1)',
+    falling: 'rgba(73, 213, 18, 1)',
+    total: 'rgba(73, 213, 18, 0)',
+  },
+});
+
+const createWaterfallPlot = ({
+  dom,
+  data,
+  config = {},
+  formatConfig,
+}: PlotCreateProps<Partial<WaterfallConfig>>) => {
+  const plot = new Waterfall(
+    dom,
+    formatMergeConfig<WaterfallConfig>(getOriginConfig(data), config, formatConfig),
+  );
 
   plot.render();
   return plot;
 };
 
-export default createSingleChart(createWaterfallPlot);
+export default createSingleChart<Partial<WaterfallConfig>, DataItem[], Waterfall>(
+  createWaterfallPlot,
+  { getOriginConfig },
+);


### PR DESCRIPTION
一、config自动深层merge
所有图表的 config 属性支持自动深层 merge，当不传入formatConfig时自动使用深层merge，不会替换父级原有属性。这样就不需要像以前一样为了防止属性替换把无用的 config 属性全部传进来，保持代码整洁。
二、图表新增formatConfig方法
所有图表新增 formatConfig 方法,自定义配置函数,传入时对 config 进行配置可以全部替换。用法类似 useImmer。
1.用法1：
![image](https://user-images.githubusercontent.com/39564114/86512731-26b38780-be37-11ea-96a1-cddc7d1d67a1.png)
用第一种做法时可以实现跟 merge 一样的效果，不会替换父级原有属性。
2.用法2：
![image](https://user-images.githubusercontent.com/39564114/86512781-a2153900-be37-11ea-8c91-67159e5920ea.png)
用第二种做法时会自动替换覆盖 yAxis 上所有属性。并支持完全自定义。
注：formatConfig 传入后会对经过 config  merge 后的 config 进行操作，即 config 属性还是会保留自动 merge 的特点。
三、引入类型
可以在 config 中输入属性的时候出现 typescript 类型提示和报错了。

