### PR TITLE
fix: 修正Badge組件顯示位置總是在子組件範圍內

### DIFF
--- a/.changeset/badge-fix.md
+++ b/.changeset/badge-fix.md
@@ -2,4 +2,4 @@
 '@td-design/react-native': patch
 ---
 
-fix: 修正Badge組件顯示位置總是在子組件範圍內
+fix: 修正Badge组件显示位置总是在子组件范围内

--- a/.changeset/badge-fix.md
+++ b/.changeset/badge-fix.md
@@ -1,0 +1,5 @@
+---
+'@td-design/react-native': patch
+---
+
+fix: 修正Badge組件顯示位置總是在子組件範圍內

--- a/packages/react-native/src/badge/index.md
+++ b/packages/react-native/src/badge/index.md
@@ -82,5 +82,6 @@ group:
 | --------------- | ------- | ---------------- | -------------------- | ---------------- |
 | type            | `false` | badge 的形态     | `dot` \| `text`      | `text`           |
 | text            | `false` | badge 的内容     | `string` \| `number` |                  |
-| overflowCount   | `false` | 展示封顶的数值   | `number`             | `99`             |
-| backgroundColor | `false` | badge 的背景颜色 | `string`             | `dangerousColor` |
+| max   | `false` | 展示封顶的数值   | `number`             | `99`             |
+| containerStyle | `false` | badge的容器的style | `ViewStyle`             |  |
+| textStyle | `false` | badge中文字的style | `ViewStyle`             |  |

--- a/packages/react-native/src/badge/useBadge.tsx
+++ b/packages/react-native/src/badge/useBadge.tsx
@@ -1,10 +1,12 @@
 import { useTheme } from '@shopify/restyle';
-import React from 'react';
-import { View } from 'react-native';
+import React, { useCallback } from 'react';
+import { LayoutChangeEvent, View } from 'react-native';
 
 import type { BadgeProps } from '.';
 import Text from '../text';
 import { Theme } from '../theme';
+import { useSafeState } from '@td-design/rn-hooks';
+
 
 const DOT_SIZE = 8; // 默认点大小
 export default function useBadge({ type = 'text', containerStyle = {}, textStyle = {}, text, max = 99 }: BadgeProps) {
@@ -15,6 +17,23 @@ export default function useBadge({ type = 'text', containerStyle = {}, textStyle
   const isZero = text === '0' || text === 0;
   const isEmpty = text === null || text === undefined || text === '';
   const isHidden = isEmpty || isZero;
+  const [badgeOffset, setBadgeOffset] = useSafeState<{ top: number; right: number }>({
+    top: 0,
+    right: 0,
+  });
+
+  const onBadgeLayout = useCallback(
+    (event: LayoutChangeEvent) => {
+      const { width, height } = event.nativeEvent.layout;
+      const newX = Math.round(-width / 2);
+      const newY = Math.round(-height / 2);
+
+      if (badgeOffset.top !== newY || badgeOffset.right !== newX) {
+        setBadgeOffset({ top: newY, right: newX });
+      }
+    },
+    [text]
+  );
 
   const contentDom =
     type === 'dot' ? (
@@ -32,11 +51,12 @@ export default function useBadge({ type = 'text', containerStyle = {}, textStyle
       />
     ) : (
       <View
+        onLayout={onBadgeLayout}
         style={{
           borderRadius: 12,
           position: 'absolute',
-          top: 0,
-          right: 0,
+          top: badgeOffset.top,
+          right: badgeOffset.right,
           paddingHorizontal: 6,
           backgroundColor: theme.colors.func600,
           justifyContent: 'center',

--- a/packages/react-native/src/badge/useBadge.tsx
+++ b/packages/react-native/src/badge/useBadge.tsx
@@ -32,7 +32,7 @@ export default function useBadge({ type = 'text', containerStyle = {}, textStyle
         setBadgeOffset({ top: newY, right: newX });
       }
     },
-    [text]
+    [badgeOffset]
   );
 
   const contentDom =


### PR DESCRIPTION
@chj-damon 
@chen929104 

### Problem

Badge 組件實際顯示位置和官方的文檔的example不一樣

如下圖, 原因是把right 和 top 固定了0

<img width="299" alt="Screenshot 2023-02-19 at 12 44 31 PM" src="https://user-images.githubusercontent.com/42508279/219922695-2c1882fe-9eb8-4620-8af5-153b772fb66f.png">

### Expected output

badge container 的一半應該是在子組件之外，這是修正後的效果

<img width="299" alt="image" src="https://user-images.githubusercontent.com/42508279/219922796-b0d070db-85f6-491c-90a5-2d2b73b8bf18.png">





