### PR TITLE
修復Notify組件autoClose:false 失效問題 和當沒有傳入onPress 時依然會顯示

### DIFF
--- a/packages/react-native/src/notify/NotifyRoot.tsx
+++ b/packages/react-native/src/notify/NotifyRoot.tsx
@@ -69,12 +69,13 @@ const NotifyRoot = forwardRef((_, ref) => {
         >
           {options.type === NotifyType.INFO ? (
             <>
-              {!!options.onClose ? (
+              {!!options.onClose && (
                 <TouchableOpacity activeOpacity={0.5} onPress={options.onClose} style={styles.content}>
                   {Content}
                   <SvgIcon name="close" color={shadowColor} />
                 </TouchableOpacity>
-              ) : (
+              )}
+              {!!options.onPress && (
                 <TouchableOpacity activeOpacity={0.5} onPress={options.onPress} style={styles.content}>
                   {Content}
                   <SvgIcon name="right" color={shadowColor} />

--- a/packages/react-native/src/notify/useNotify.ts
+++ b/packages/react-native/src/notify/useNotify.ts
@@ -52,7 +52,7 @@ export default function useNotify() {
   }, [visible]);
 
   useEffect(() => {
-    if (!visible || !options?.duration) return;
+    if (!visible || !options?.duration || !options?.autoClose) return;
 
     timer.current = setTimeout(() => {
       displayed.value = withTiming(0, { duration: 300, easing: Easing.inOut(Easing.ease) }, finished => {


### PR DESCRIPTION
### Issues

@chj-damon 
主要修復兩個問題
1. autoClose 為false時，Notify組件依然會自動隱藏
2. 當TYPE 為info並沒有傳入onPress 回調函數時，會顯示右箭頭，和[官方文檔第一個example](https://thundersdata-frontend.github.io/td-design/react-native/feedback/notify/#1-%E6%B6%88%E6%81%AF%E6%8F%90%E7%A4%BA)不一樣 

![2023-03-09 16 46 48](https://user-images.githubusercontent.com/42508279/223971288-6acf03c6-d105-40a0-839a-9e43d0466dc9.gif)

